### PR TITLE
Create error for trailing characters

### DIFF
--- a/fql/src/grammar/expr.rs
+++ b/fql/src/grammar/expr.rs
@@ -343,7 +343,7 @@ mod tests {
         check(
             "host.online:><true",
             expect![[r#"
-                Root@0..14
+                Root@0..18
                   Clause@0..14
                     Property@0..11
                       Ident@0..4 "host"
@@ -354,8 +354,11 @@ mod tests {
                       Gt@12..13 ">"
                     Error@13..14
                       Lt@13..14 "<"
+                  Error@14..18
+                    Boolean@14..18 "true"
 
-                At 13..14, expected '[', boolean, string, or integer, found '<'"#]],
+                At 13..14, expected '[', boolean, string, or integer, found '<'
+                At 14..18, expected '+', or ',', found boolean"#]],
         )
     }
 
@@ -364,7 +367,7 @@ mod tests {
         check(
             "host.online:?true",
             expect![[r#"
-                Root@0..13
+                Root@0..17
                   Clause@0..13
                     Property@0..11
                       Ident@0..4 "host"
@@ -373,8 +376,11 @@ mod tests {
                     Colon@11..12 ":"
                     Error@12..13
                       Error@12..13 "?"
+                  Error@13..17
+                    Boolean@13..17 "true"
 
-                At 12..13, expected '!', '>', '<', '>=', '<=', '~', '!~', '[', boolean, string, or integer, found error"#]],
+                At 12..13, expected '!', '>', '<', '>=', '<=', '~', '!~', '[', boolean, string, or integer, found error
+                At 13..17, expected '+', or ',', found boolean"#]],
         )
     }
 
@@ -416,5 +422,70 @@ mod tests {
                       Literal@17..20
                         Integer@17..20 "100""#]],
         )
+    }
+
+    #[test]
+    fn unclosed_parentheses() {
+        check(
+            "(host.online:true",
+            expect![[r#"
+            Root@0..17
+              ParenExpr@0..17
+                LParen@0..1 "("
+                Clause@1..17
+                  Property@1..12
+                    Ident@1..5 "host"
+                    Period@5..6 "."
+                    Ident@6..12 "online"
+                  Colon@12..13 ":"
+                  Operand@13..17
+                    Literal@13..17
+                      Boolean@13..17 "true"
+
+            At 13..17, expected '+', ',', or ')'"#]],
+        )
+    }
+
+    #[test]
+    fn orphan_rparen() {
+        check(
+            "host.online:true)",
+            expect![[r#"
+            Root@0..17
+              Clause@0..16
+                Property@0..11
+                  Ident@0..4 "host"
+                  Period@4..5 "."
+                  Ident@5..11 "online"
+                Colon@11..12 ":"
+                Operand@12..16
+                  Literal@12..16
+                    Boolean@12..16 "true"
+              Error@16..17
+                RParen@16..17 ")"
+
+            At 16..17, expected '+', or ',', found ')'"#]],
+        )
+    }
+
+    #[test]
+    fn trailing_operators() {
+        check("host.online:true>>", expect![[r#"
+            Root@0..18
+              Clause@0..16
+                Property@0..11
+                  Ident@0..4 "host"
+                  Period@4..5 "."
+                  Ident@5..11 "online"
+                Colon@11..12 ":"
+                Operand@12..16
+                  Literal@12..16
+                    Boolean@12..16 "true"
+              Error@16..18
+                Gt@16..17 ">"
+                Gt@17..18 ">"
+
+            At 16..17, expected '+', or ',', found '>'
+            At 17..18, expected nothing, found '>'"#]])
     }
 }

--- a/fql/src/grammar/property.rs
+++ b/fql/src/grammar/property.rs
@@ -83,14 +83,17 @@ mod tests {
         check(
             "host..online",
             expect![[r#"
-            Root@0..6
-              Property@0..6
-                Ident@0..4 "host"
-                Period@4..5 "."
-                Error@5..6
-                  Period@5..6 "."
+                Root@0..12
+                  Property@0..6
+                    Ident@0..4 "host"
+                    Period@4..5 "."
+                    Error@5..6
+                      Period@5..6 "."
+                  Error@6..12
+                    Ident@6..12 "online"
 
-            At 5..6, expected ident, found '.'"#]],
+                At 5..6, expected ident, found '.'
+                At 6..12, expected '.', found ident"#]],
         )
     }
 

--- a/fql/src/parser/error.rs
+++ b/fql/src/parser/error.rs
@@ -15,11 +15,17 @@ impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "At {}..{}, expected {}",
+            "At {}..{}, expected ",
             u32::from(self.range.start()),
             u32::from(self.range.end()),
-            FriendlyList(&self.expected)
         )?;
+
+        if self.expected.is_empty() {
+            write!(f, "nothing")?;
+        } else {
+            write!(f, "{}", FriendlyList(&self.expected))?;
+        }
+
         if let Some(found) = self.found {
             write!(f, ", found {}", found)?;
         }


### PR DESCRIPTION
Trailing characters are now all consumed. 

To avoid losing characters going forward, a new assertion is added to the tests that the CST span is the same length as the input text.

Fixes #3